### PR TITLE
Fix gem spec dependency

### DIFF
--- a/activerecord-import.gemspec
+++ b/activerecord-import.gemspec
@@ -51,18 +51,15 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<activerecord>, ["~> 3.0"])
       s.add_development_dependency(%q<rake>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, [">= 1.4.0"])
-      s.add_runtime_dependency(%q<activerecord>, ["~> 3.0"])
     else
       s.add_dependency(%q<activerecord>, ["~> 3.0"])
       s.add_dependency(%q<rake>, [">= 0"])
       s.add_dependency(%q<jeweler>, [">= 1.4.0"])
-      s.add_dependency(%q<activerecord>, ["~> 3.0"])
     end
   else
     s.add_dependency(%q<activerecord>, ["~> 3.0"])
     s.add_dependency(%q<rake>, [">= 0"])
     s.add_dependency(%q<jeweler>, [">= 1.4.0"])
-    s.add_dependency(%q<activerecord>, ["~> 3.0"])
   end
 end
 


### PR DESCRIPTION
## 問題

bundle installすると下記のエラーが出る

```
The gemspec at
/path/to/vendor/bundle/ruby/2.0.0/bundler/gems/activerecord-import-8b555fb2757d/activerecord-import.gemspec
is not valid. The validation error was 'duplicate dependency on activerecord (~>
3.0), (~> 3.0) use:
    add_runtime_dependency 'activerecord', '~> 3.0', '~> 3.0'
'
```
## 原因

bundlerのバージョンを1.10以上の場合にgemspecの検証が厳しくなり、activerecord-importのgemspecがおかしいためインストールできなくなっていた。
## 対応

gemspecで記述が重複しているものを消しました。
